### PR TITLE
Use built‑in fetch and async fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@node-minify/terser": "^9.0.1",
     "http-server": "^14.1.1",
     "node-7z": "^3.0.0",
-    "node-fetch": "^3.3.2",
     "nipplejs": "^0.10.2",
     "socket.io": "^4.8.1",
     "jsonwebtoken": "^9.0.2"


### PR DESCRIPTION
## Summary
- refactor `update.js` to use `fs/promises`
- rely on Node's built-in `fetch`
- drop `node-fetch` from `package.json`

## Testing
- `node --check update.js`
- `node -e "console.log('fetch' in globalThis)"`

------
https://chatgpt.com/codex/tasks/task_e_688924ba7a748331b957d4f221d5582e