### PR TITLE
Refactor screenshot polling and add test

### DIFF
--- a/__tests__/game-manager.test.js
+++ b/__tests__/game-manager.test.js
@@ -1,0 +1,31 @@
+import { jest } from '@jest/globals';
+
+beforeAll(async () => {
+  global.window = {};
+  await import('../data/src/GameManager.js');
+});
+
+describe('GameManager screenshot', () => {
+  test('resolves when screenshot file appears', async () => {
+    jest.useFakeTimers();
+    const FS = {
+      files: {},
+      unlink: jest.fn(path => { delete FS.files[path]; }),
+      stat: jest.fn(path => { if (!(path in FS.files)) throw new Error('ENOENT'); }),
+      readFile: jest.fn(path => FS.files[path])
+    };
+    const gm = Object.create(global.window.EJS_GameManager.prototype);
+    gm.FS = FS;
+    gm.functions = { screenshot: jest.fn() };
+
+    const promise = gm.screenshot();
+    setTimeout(() => { FS.files['/screenshot.png'] = new Uint8Array([1,2,3]); }, 20);
+
+    jest.advanceTimersByTime(20);
+    jest.advanceTimersByTime(50);
+
+    const data = await promise;
+    expect(data).toEqual(new Uint8Array([1,2,3]));
+    jest.useRealTimers();
+  });
+});

--- a/data/src/GameManager.js
+++ b/data/src/GameManager.js
@@ -213,15 +213,16 @@ class EJS_GameManager {
             this.FS.unlink("screenshot.png");
         } catch(e) {}
         this.functions.screenshot();
-        return new Promise(async resolve => {
-            while (1) {
+        return new Promise(resolve => {
+            const check = setInterval(() => {
                 try {
                     this.FS.stat("/screenshot.png");
-                    return resolve(this.FS.readFile("/screenshot.png"));
-                } catch(e) {}
-                await new Promise(res => setTimeout(res, 50));
-            }
-        })
+                    const data = this.FS.readFile("/screenshot.png");
+                    clearInterval(check);
+                    resolve(data);
+                } catch (e) {}
+            }, 50);
+        });
     }
     quickSave(slot) {
         if (!slot) slot = 1;


### PR DESCRIPTION
## Summary
- refactor screenshot method to poll asynchronously via `setInterval`
- add unit test for new screenshot behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68892ff38a8c8331b40213bf68265749