### PR TITLE
Auto netplay server + join toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Set these environment variables before launching:
 - **`PORT`** – listening port (default `8080`)
 - **`API_KEY`** – secret for issuing JWT tokens
 - **`ADMIN_KEY`** – key required for the management API
+- **`ALLOW_PLAYER_JOIN`** – set to `false` to prevent new players from joining
+- **`ALLOW_VIEWER_JOIN`** – set to `false` to prevent new viewers from joining
 
 Example:
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/EmulatorJS/EmulatorJS/issues"
   },
   "scripts": {
-    "start": "http-server",
+    "start": "node start.js",
     "minify": "node minify/minify.js",
     "build": "node build.js",
     "update": "node update.js",

--- a/server/netplay-server.js
+++ b/server/netplay-server.js
@@ -7,6 +7,8 @@ import jwt from 'jsonwebtoken';
 const PORT = parseInt(process.env.PORT || '8080', 10);
 const API_KEY = process.env.API_KEY || '';
 const ADMIN_KEY = process.env.ADMIN_KEY || '';
+const ALLOW_PLAYER_JOIN = process.env.ALLOW_PLAYER_JOIN !== 'false';
+const ALLOW_VIEWER_JOIN = process.env.ALLOW_VIEWER_JOIN !== 'false';
 
 /**
  * Room structure
@@ -44,10 +46,12 @@ function joinRoom(id, socket, { spectator = false, password = '', name = '', gui
   if (room.password && room.password !== password) return { error: 'bad-password' };
   if (room.allowedUsers && !room.allowedUsers.has(guid)) return { error: 'not-allowed' };
   if (spectator || room.players.size >= room.maxPlayers) {
+    if (!ALLOW_VIEWER_JOIN) return { error: 'viewers-disabled' };
     if (room.viewers.size >= room.maxViewers) return { error: 'room-full' };
     room.viewers.set(socket.id, { name, guid });
     return { player: null, spectator: true, name, guid };
   }
+  if (!ALLOW_PLAYER_JOIN) return { error: 'players-disabled' };
   const playerNum = room.players.size + 1;
   room.players.set(socket.id, { num: playerNum, name, guid });
   return { player: playerNum, spectator: false, name, guid };

--- a/start.js
+++ b/start.js
@@ -1,0 +1,25 @@
+import { spawn } from 'child_process';
+import { resolve } from 'path';
+
+function run(cmd, args) {
+  const child = spawn(cmd, args, { stdio: 'inherit' });
+  child.on('close', code => {
+    if (code && code !== 0) {
+      console.error(`${cmd} exited with code ${code}`);
+    }
+  });
+  return child;
+}
+
+const procs = [];
+procs.push(run('http-server', []));
+procs.push(run('node', [resolve('server', 'netplay-server.js')]));
+
+function shutDown(signal) {
+  for (const p of procs) {
+    p.kill(signal);
+  }
+}
+process.on('SIGINT', () => shutDown('SIGINT'));
+process.on('SIGTERM', () => shutDown('SIGTERM'));
+


### PR DESCRIPTION
## Summary
- add start script that launches both http-server and the netplay server
- allow disabling player or viewer join via `ALLOW_PLAYER_JOIN` and `ALLOW_VIEWER_JOIN`
- document the new environment variables

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889330230708331bf38bf64a37bf311